### PR TITLE
Add better handling of some combinations between n_clients and client_names

### DIFF
--- a/flex/data/flex_data_distribution.py
+++ b/flex/data/flex_data_distribution.py
@@ -44,9 +44,14 @@ class FlexDataDistribution(object):
             config_.weights = np.array(
                 [w / sum(config.weights) for w in config.weights]
             )
-        if (  # If no client_names, then we index clients with integers
-            config_.client_names is None
-        ):
+
+        if config_.client_names is not None and config_.n_clients is not None:
+            common_min = min(config_.n_clients, len(config_.client_names))
+            config_.n_clients = common_min
+            config_.client_names = config_.client_names[:common_min]
+        elif config_.client_names is not None:
+            config_.n_clients = len(config_.client_names)
+        elif config_.n_clients is not None:
             config_.client_names = list(range(config_.n_clients))
 
         fed_dataset = FlexDataset()

--- a/tests/data/test_flex_data_distribution.py
+++ b/tests/data/test_flex_data_distribution.py
@@ -16,6 +16,16 @@ class TestFlexDataDistribution(unittest.TestCase):
         X_data = np.random.rand(100).reshape([20, 5])
         y_data = np.random.choice(2, 20)
         fcd = FlexDataObject(X_data=X_data, y_data=y_data)
+        config = FlexDatasetConfig(client_names=["Juan", "Pepe", 2])
+        flex_dataset = FlexDataDistribution.from_config(fcd, config)
+        assert "Juan" in flex_dataset
+        assert "Pepe" in flex_dataset
+        assert 2 in flex_dataset
+
+    def test_client_names_bis(self):
+        X_data = np.random.rand(100).reshape([20, 5])
+        y_data = np.random.choice(2, 20)
+        fcd = FlexDataObject(X_data=X_data, y_data=y_data)
         config = FlexDatasetConfig(n_clients=3, client_names=["Juan", "Pepe", 2])
         flex_dataset = FlexDataDistribution.from_config(fcd, config)
         assert "Juan" in flex_dataset


### PR DESCRIPTION
When `client_names`and `n_clients` we provided, `FlexDataDistribution.from_config` crashed. Added test to fix that issue.