### PR TITLE
Added defaultdict as default value for flex_models.

### DIFF
--- a/flex/pool/flex_pool.py
+++ b/flex/pool/flex_pool.py
@@ -1,4 +1,5 @@
 import functools
+from collections import defaultdict
 from typing import Callable
 
 from flex.data import FlexDataset
@@ -14,7 +15,7 @@ class FlexPool:
         self,
         flex_data: FlexDataset,
         flex_actors: FlexActors,
-        flex_models=None,
+        flex_models: defaultdict,
         dropout_rate: float = None,
     ) -> None:
         self._actors = flex_actors  # Actors
@@ -48,7 +49,7 @@ class FlexPool:
                 if actor_id in self._data:
                     new_data[actor_id] = self._data[actor_id]
                 # TODO: Add Model when Model module is finished.
-        new_models = None
+        new_models = defaultdict()
         return FlexPool(
             flex_actors=new_actors, flex_data=new_data, flex_models=new_models
         )
@@ -111,7 +112,7 @@ class FlexPool:
         return cls(
             flex_data=fed_dataset,
             flex_actors=actors,
-            flex_models=None,
+            flex_models=defaultdict(),
             dropout_rate=dropout_rate,
         )
 
@@ -120,7 +121,7 @@ class FlexPool:
         return cls(
             flex_data=fed_dataset,
             flex_actors=cls.__create_actors_all_privileges(fed_dataset.keys()),
-            flex_models=None,
+            flex_models=defaultdict(),
             dropout_rate=dropout_rate,
         )
 

--- a/tests/pool/test_flex_pool.py
+++ b/tests/pool/test_flex_pool.py
@@ -1,4 +1,5 @@
 import unittest
+from collections import defaultdict
 
 import numpy as np
 import pytest
@@ -92,7 +93,13 @@ class TestRoleManger(unittest.TestCase):
             {"client_1": self._fld["client_1"], "client_2": self._fld["client_2"]}
         )
         with pytest.raises(ValueError):
-            FlexPool(fld, self._only_clients)
+            FlexPool(fld, self._only_clients, defaultdict())
+
+    def test_validate_client_without_model(self):
+        p = FlexPool.p2p_architecture(self._fld)
+        assert p._models.get("client_1") is None
+        assert p._models.get("client_2") is None
+        assert p._models.get("client_3") is None
 
     def test_filter(self):
         p = FlexPool.p2p_architecture(self._fld)


### PR DESCRIPTION
 To get None as a result of asking for the model of a client that doesn't have any, the user must use ALWAYS the get function, either, if using the [], it will output KeyError.