### PR TITLE
Now we create a copy of the actors keys as a list because of a bug with Python 3.11 that doens't support a dict.keys() in the random.sample function.

### DIFF
--- a/flex/pool/pool.py
+++ b/flex/pool/pool.py
@@ -150,7 +150,7 @@ class FlexPool:
         new_actors = FlexActors()
         new_data = FedDataset()
         new_models = {}
-        available_nodes = self._actors.keys()
+        available_nodes = list(self._actors.keys())
         if callable(criteria):
             selected_keys = [
                 actor_id


### PR DESCRIPTION
Now we create a copy of the actors keys as a list because of a bug with Python 3.11 that doens't support a dict.keys() in the random.sample function.